### PR TITLE
Feature/md2html module tests

### DIFF
--- a/nodecli/main.js
+++ b/nodecli/main.js
@@ -1,6 +1,8 @@
 const program = require('commander');
 const fs = require('fs');
-const marked = require('marked');
+
+// md2htmlモジュールをインポート
+const md2html = require('./md2html')
 
 // gfmオプションの定義
 program.option("--gfm", "gfmを有効にする");
@@ -10,7 +12,7 @@ const filePath = program.args[0];
 const cliOptions = {
   gfm: false,
   ...program.opts(),
-}
+};
 
 // ファイルの非同期読み込み
 fs.readFile(filePath, { encoding: 'utf-8' }, (err, file) => {
@@ -21,11 +23,8 @@ fs.readFile(filePath, { encoding: 'utf-8' }, (err, file) => {
     return;
   }
 
-  const html = marked(file, {
-    // オプションの値を使用
-    gfm: cliOptions.gfm,
-  });
-
+  // md2htmlモジュールを使ったHTMLへの変換
+  const html = md2html(file, cliOptions);
   console.log(html);
 });
 

--- a/nodecli/md2html.js
+++ b/nodecli/md2html.js
@@ -1,0 +1,7 @@
+const marked = require('marked');
+
+module.exports = (markdown, cliOptions) => {
+  return marked(markdown, {
+    gfm: cliOptions.gfm,
+  });
+}

--- a/nodecli/package.json
+++ b/nodecli/package.json
@@ -10,5 +10,8 @@
   },
   "devDependencies": {
     "mocha": "^8.3.2"
+  },
+  "scripts": {
+    "test": "mocha test/"
   }
 }

--- a/nodecli/package.json
+++ b/nodecli/package.json
@@ -6,7 +6,9 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^7.1.0",
-    "marked": "^2.0.1",
+    "marked": "^2.0.1"
+  },
+  "devDependencies": {
     "mocha": "^8.3.2"
   }
 }

--- a/nodecli/test/fixtures/expected-gfm.html
+++ b/nodecli/test/fixtures/expected-gfm.html
@@ -1,0 +1,7 @@
+<h1 id="sample_file_test">sample_file_test</h1>
+<p>これはサンプルです
+<a href="https://huro3h.com">https://huro3h.com</a></p>
+<ul>
+<li>hoge1</li>
+<li>hoge2</li>
+</ul>

--- a/nodecli/test/fixtures/expected.html
+++ b/nodecli/test/fixtures/expected.html
@@ -1,0 +1,7 @@
+<h1 id="sample_file_test">sample_file_test</h1>
+<p>これはサンプルです
+https://huro3h.com</p>
+<ul>
+<li>hoge1</li>
+<li>hoge2</li>
+</ul>

--- a/nodecli/test/fixtures/sample.md
+++ b/nodecli/test/fixtures/sample.md
@@ -1,0 +1,7 @@
+# sample_file_test
+
+これはサンプルです
+https://huro3h.com
+
+- hoge1
+- hoge2

--- a/nodecli/test/md2html-test.js
+++ b/nodecli/test/md2html-test.js
@@ -1,0 +1,15 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const md2html = require("../md2html");
+
+it("マークダウンからHTMLに変換できること(gfm: false)", () => {
+  // fs.readFileSyncは同期的にファイルを読み込むメソッド
+  const sample = fs.readFileSync(path.resolve(__dirname,
+    "./fixtures/sample.md"), { encoding: "utf-8" });
+
+  const expected = fs.readFileSync(path.resolve(__dirname,
+    "./fixtures/expected.html"), { encoding: "utf-8" });
+
+  assert.strictEqual(md2html(sample, { gfm: false }), expected);
+});

--- a/nodecli/test/md2html-test.js
+++ b/nodecli/test/md2html-test.js
@@ -13,3 +13,14 @@ it("マークダウンからHTMLに変換できること(gfm: false)", () => {
 
   assert.strictEqual(md2html(sample, { gfm: false }), expected);
 });
+
+it("マークダウンからHTMLに変換できること(gfm: true)", () => {
+  // fs.readFileSyncは同期的にファイルを読み込むメソッド
+  const sample = fs.readFileSync(path.resolve(__dirname,
+    "./fixtures/sample.md"), { encoding: "utf-8" });
+
+  const expected = fs.readFileSync(path.resolve(__dirname,
+    "./fixtures/expected-gfm.html"), { encoding: "utf-8" });
+
+  assert.strictEqual(md2html(sample, { gfm: true }), expected);
+});


### PR DESCRIPTION
31.5.4  モジュールが正常に動作することを確認する自動テストの追加まで   
```shell  
$ yarn test
yarn run v1.22.10
$ mocha test/


  ✓ マークダウンからHTMLに変換できること(gfm: false)
  ✓ マークダウンからHTMLに変換できること(gfm: true)

  2 passing (27ms)

✨  Done in 0.33s.
```
